### PR TITLE
DM-39857: Stop using pytest-flake8 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ line_length = 110
 write_to = "python/lsst/ci/middleware/version.py"
 
 [tool.pytest.ini_options]
-addopts = "--flake8"
-flake8-ignore = ["E203", "W503", "N802", "N803", "N806", "N812", "N815", "N816"]
+addopts = "--import-mode=importlib"  # Recommended as best practice
 # Some unit tests open registry database and don't close it.
 open_files_ignore = ["gen3.sqlite3"]


### PR DESCRIPTION
We don't use sconsUtils for running the tests by the look of it so the changes in lsst/sconsUtils#115 won't lead to flake8/ruff running in this package.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
