### PR TITLE
DM-40243: test for unbounded refcat lookups in FGCM

### DIFF
--- a/data/SConscript
+++ b/data/SConscript
@@ -64,7 +64,7 @@ state.targets["data"].extend(ci_hsc)
 # just a few non-overlapping tracts.  We do care here about giving full visits
 # to steps that expect full visits (no "tract slicing"), and that's the main
 # reason for splitting up into steps.  For the mock version, we process just
-# one tract (0), and deliberately leave out the two visit here (18202, 96980)
+# one tract (0), and deliberately leave out the two visits here (18202, 96980)
 # that doesn't overlap it.
 rc2 = (
     PipelineCommands(

--- a/python/lsst/ci/middleware/display.py
+++ b/python/lsst/ci/middleware/display.py
@@ -32,7 +32,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from typing import Any, cast
 
-import bokeh.plotting.figure
+import bokeh.plotting
 import numpy as np
 from lsst.afw.geom import makeCdMatrix, makeSkyWcs
 from lsst.daf.butler import Butler, DataCoordinate, DimensionRecord, DimensionUniverse, SkyPixDimension
@@ -193,7 +193,7 @@ class DimensionDisplay:
                     universe[element].RecordClass(id=id, region=pixelization.pixel(id)), update_bbox=False
                 )
 
-    def draw(self) -> bokeh.plotting.Figure:
+    def draw(self) -> bokeh.plotting.figure:
         """Create a Bokeh figure object from the records that have been added.
 
         Returns

--- a/tests/test_rc2_outputs.py
+++ b/tests/test_rc2_outputs.py
@@ -23,7 +23,7 @@ import unittest
 from typing import ClassVar
 
 from lsst.ci.middleware.output_repo_tests import OutputRepoTests
-from lsst.pipe.base.tests.mocks import get_mock_name
+from lsst.pipe.base.tests.mocks import MockDataset, get_mock_name
 
 # (tract, patch, band): {input visits} for coadds produced here.
 # some visit lists elided because we're just spot-checking.
@@ -150,6 +150,20 @@ class Rc2OutputsTestCase(unittest.TestCase):
 
     def test_step8_rescue_qbb(self) -> None:
         self.check_step8_rescue(self.qbb)
+
+    def test_fgcm_refcats(self) -> None:
+        """Test that FGCM does not get refcats that don't overlap any of its
+        inputs or outputs, despite not having a spatial data ID.
+        """
+        fgcm_reference_stars: MockDataset = self.qbb.butler.get(
+            get_mock_name("fgcm_reference_stars"), instrument="HSC"
+        )
+        htm7_indices = {
+            input.ref.dataId.dataId["htm7"]  # type: ignore
+            for input in fgcm_reference_stars.quantum.inputs["ref_cat"]  # type: ignore
+        }
+        self.assertNotIn(231819, htm7_indices)
+        self.assertIn(231865, htm7_indices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Checklist

- [x] ran ~Jenkins~ local lsstsw
- [x] added a release note for user-visible changes to `doc/changes` (in pipe_base)
