### PR TITLE
DM-40381: test coverage for init-input/output flow, especially with QBB

### DIFF
--- a/data/SConscript
+++ b/data/SConscript
@@ -81,7 +81,7 @@ rc2 = (
     .add("step7")
     # Test fail-and-rescue workflow by configuring one task fail on the first
     # try, and then recover from that with a new run and --skip-existing-in.
-    .add("step8", group="attempt1", fail=["analyzeObjectTableCore::'skymap='ci_mw' AND tract=0'"])
+    .add("step8", group="attempt1", fail=['''analyzeObjectTableCore::"skymap='ci_mw' AND tract=0"'''])
     .add("step8", group="attempt2", skip_existing_in_last=True)
     .finish()
 )
@@ -101,7 +101,13 @@ prod = (
     # Using band for grouping here is just a convenient to split our visits up
     # into two groups, not a reflection of expected real pipeline usage.
     .add("step1", group="r", where="band='r'")
-    .add("step1", group="i", where="band='i'")
+    .add(
+        "step1",
+        group="i-attempt1",
+        where="band='i'",
+        fail=['''calibrate::"instrument='HSC' AND visit=18202"'''],
+    )
+    .add("step1", group="i-attempt2", where="band='i'", skip_existing_in_last=True)
     .add("step2a", group="r", where="band='r'")
     .add("step2a", group="i", where="band='i'")
     .add("step2b", group="even", where="skymap='ci_mw' AND tract IN (0, 2)")

--- a/python/lsst/ci/middleware/mock_dataset_maker.py
+++ b/python/lsst/ci/middleware/mock_dataset_maker.py
@@ -149,7 +149,15 @@ class MockDatasetMaker:
                 self.cached_data_ids[dimensions] = data_ids
         for data_id in data_ids:
             ref = DatasetRef(dataset_type, data_id, run=run)
-            self.butler.put(MockDataset(ref=ref.to_simple()), ref)
+            self.butler.put(
+                MockDataset(
+                    dataset_id=ref.id,
+                    dataset_type=dataset_type.to_simple(),
+                    data_id=data_id.full.byName(),
+                    run=run,
+                ),
+                ref,
+            )
 
     @property
     def spatial_bounds(self) -> Box:

--- a/python/lsst/ci/middleware/output_repo_tests.py
+++ b/python/lsst/ci/middleware/output_repo_tests.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import cast
 
 from lsst.daf.base import PropertySet
-from lsst.daf.butler import Butler, SerializedDataCoordinate
+from lsst.daf.butler import Butler
 from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
 from lsst.pipe.base import QuantumGraph, TaskMetadata
 from lsst.pipe.base.tests.mocks import MockDataset, MockDatasetQuantum, get_mock_name
@@ -134,9 +134,7 @@ class OutputRepoTests:
             test_case.assertIsNone(tract_dataset.converted_from)
             assert tract_dataset.quantum is not None
             for patch_dataset_as_input in tract_dataset.quantum.inputs["inputCatalogs"]:
-                patch = cast(
-                    int, cast(SerializedDataCoordinate, patch_dataset_as_input.ref.dataId).dataId["patch"]
-                )
+                patch = cast(int, patch_dataset_as_input.data_id["patch"])
                 patch_ref = patch_refs[tract, patch]
                 # We pre-registered this dataset type with ArrowTable as its
                 # storage class, even though the task connections all use
@@ -173,7 +171,7 @@ class OutputRepoTests:
             if (expected := self.expected[key]) is not None:
                 test_case.assertEqual(
                     {
-                        cast(SerializedDataCoordinate, input_dataset.ref.dataId).dataId["visit"]
+                        input_dataset.data_id["visit"]
                         for input_dataset in cast(MockDatasetQuantum, dataset.quantum).inputs["inputWarps"]
                     },
                     expected,

--- a/tests/test_mock_storage_class.py
+++ b/tests/test_mock_storage_class.py
@@ -73,7 +73,12 @@ class MockStorageClassTestCase(unittest.TestCase):
                 run=run,
             )
             # Make a dataset with this storage class and put it.
-            in_memory_dataset = MockDataset(ref=dataset_ref.to_simple())
+            in_memory_dataset = MockDataset(
+                dataset_id=dataset_ref.id,
+                dataset_type=dataset_ref.datasetType.to_simple(),
+                data_id=dataset_ref.dataId.full.byName(),
+                run=dataset_ref.run,
+            )
             butler.put(in_memory_dataset, dataset_ref)
             # Get the original dataset back.
             got_direct: MockDataset = butler.get(dataset_ref)
@@ -83,7 +88,7 @@ class MockStorageClassTestCase(unittest.TestCase):
             bbox = Box2I(Point2I(1, 2), Point2I(5, 4))
             got_parameterized: MockDataset = butler.get(dataset_ref, parameters={"bbox": bbox})
             self.assertIsInstance(got_parameterized, MockDataset)
-            self.assertEqual(got_parameterized.ref, in_memory_dataset.ref)
+            self.assertEqual(got_parameterized.dataset_id, in_memory_dataset.dataset_id)
             self.assertEqual(got_parameterized.parameters, {"bbox": repr(bbox)})
             # Get a regular component.
             got_wcs: MockDataset = butler.get(dataset_ref.makeComponentRef("wcs"))
@@ -114,7 +119,10 @@ class MockStorageClassTestCase(unittest.TestCase):
                 run=run,
             )
             put_convert_in = MockDataset(
-                ref=put_convert_dataset_ref.overrideStorageClass(derived_storage_class).to_simple()
+                dataset_id=put_convert_dataset_ref.id,
+                dataset_type=put_convert_dataset_type.overrideStorageClass(derived_storage_class).to_simple(),
+                data_id=put_convert_dataset_ref.dataId.full.byName(),
+                run=put_convert_dataset_ref.run,
             )
             butler.put(put_convert_in, put_convert_dataset_ref)
             put_convert_out: MockDataset = butler.get(put_convert_dataset_ref)
@@ -145,10 +153,20 @@ class MockStorageClassTestCase(unittest.TestCase):
             # put but a TypeError on get.
             with self.assertRaises(TypeError):
                 butler.put(
-                    MockDataset(ref=derived_dataset_ref.overrideStorageClass(storage_class).to_simple()),
+                    MockDataset(
+                        dataset_id=derived_dataset_ref.id,
+                        dataset_type=derived_dataset_type.overrideStorageClass(storage_class).to_simple(),
+                        data_id=derived_dataset_ref.dataId.full.byName(),
+                        run=derived_dataset_ref.run,
+                    ),
                     derived_dataset_ref,
                 )
-            derived_in = MockDataset(ref=derived_dataset_ref.to_simple())
+            derived_in = MockDataset(
+                dataset_id=derived_dataset_ref.id,
+                dataset_type=derived_dataset_type.to_simple(),
+                data_id=derived_dataset_ref.dataId.full.byName(),
+                run=derived_dataset_ref.run,
+            )
             butler.put(derived_in, derived_dataset_ref)
             got_converted: MockDataset = butler.get(derived_dataset_ref.overrideStorageClass(storage_class))
             self.assertIsInstance(got_converted, MockDataset)

--- a/tests/test_rc2_outputs.py
+++ b/tests/test_rc2_outputs.py
@@ -159,8 +159,7 @@ class Rc2OutputsTestCase(unittest.TestCase):
             get_mock_name("fgcm_reference_stars"), instrument="HSC"
         )
         htm7_indices = {
-            input.ref.dataId.dataId["htm7"]  # type: ignore
-            for input in fgcm_reference_stars.quantum.inputs["ref_cat"]  # type: ignore
+            input.data_id["htm7"] for input in fgcm_reference_stars.quantum.inputs["ref_cat"]  # type: ignore
         }
         self.assertNotIn(231819, htm7_indices)
         self.assertIn(231865, htm7_indices)


### PR DESCRIPTION
Depends on lsst/pipe_base#368 and lsst/daf_butler#879

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes` (in pipe_base and daf_butler)
