### PR TITLE
DM-44057: Add dependencies on Butler accessory packages

### DIFF
--- a/ups/ci_middleware.table
+++ b/ups/ci_middleware.table
@@ -10,5 +10,12 @@ setupRequired(obs_subaru)
 setupRequired(skymap)
 setupRequired(ctrl_mpexec)
 setupRequired(drp_pipe)
+# daf_butler_migrate and dax_obscore are not actually needed by ci_middleware,
+# but they have frequently been broken by daf_butler changes.  People usually
+# test ci_middleware when changing daf_butler, so adding them as
+# pseudo-dependencies here should reduce the likelihood of breakage in these
+# packages.
+setupRequired(daf_butler_migrate)
+setupRequired(dax_obscore)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
To ensure that they get tested in Jenkins runs, add dependencies on daf_butler_migrate and dax_obscore.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
