### PR TITLE
DM-44368: Include number of expected instances in pipetask report task-level summary

### DIFF
--- a/doc/changes/DM-44368.feature.md
+++ b/doc/changes/DM-44368.feature.md
@@ -1,0 +1,1 @@
+Add tests for counts of expected quanta in `pipetask report`.

--- a/python/lsst/ci/middleware/output_repo_tests.py
+++ b/python/lsst/ci/middleware/output_repo_tests.py
@@ -134,6 +134,8 @@ class OutputRepoTests:
             test_case.assertIsNone(tract_dataset.converted_from)
             assert tract_dataset.quantum is not None
             for patch_dataset_as_input in tract_dataset.quantum.inputs["inputCatalogs"]:
+                if not isinstance(patch_dataset_as_input, MockDataset):
+                    continue
                 patch = cast(int, patch_dataset_as_input.data_id["patch"])
                 patch_ref = patch_refs[tract, patch]
                 # We pre-registered this dataset type with ArrowTable as its
@@ -171,7 +173,7 @@ class OutputRepoTests:
             if (expected := self.expected[key]) is not None:
                 test_case.assertEqual(
                     {
-                        input_dataset.data_id["visit"]
+                        cast(MockDataset, input_dataset).data_id["visit"]
                         for input_dataset in cast(MockDatasetQuantum, dataset.quantum).inputs["inputWarps"]
                     },
                     expected,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy
 lsst-daf-butler @ git+https://github.com/lsst/daf_butler@main
 lsst-utils @ git+https://github.com/lsst/utils@main
 lsst-resources @ git+https://github.com/lsst/resources@main
-lsst-pipe-base @ git+https://github.com/lsst/pipe_base@tickets/DM-44368
-lsst-ctrl-mpexec @ git+https://github.com/lsst/ctrl_mpexec@tickets/DM-44368
+lsst-pipe-base @ git+https://github.com/lsst/pipe_base@main
+lsst-ctrl-mpexec @ git+https://github.com/lsst/ctrl_mpexec@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy
 lsst-daf-butler @ git+https://github.com/lsst/daf_butler@main
 lsst-utils @ git+https://github.com/lsst/utils@main
 lsst-resources @ git+https://github.com/lsst/resources@main
-lsst-pipe-base @ git+https://github.com/lsst/pipe_base@main
-lsst-ctrl-mpexec @ git+https://github.com/lsst/ctrl_mpexec@main
+lsst-pipe-base @ git+https://github.com/lsst/pipe_base@tickets/DM-44368
+lsst-ctrl-mpexec @ git+https://github.com/lsst/ctrl_mpexec@tickets/DM-44368

--- a/tests/test_prod_outputs.py
+++ b/tests/test_prod_outputs.py
@@ -139,6 +139,18 @@ class ProdOutputsTestCase(unittest.TestCase):
         qg_1 = helper.get_quantum_graph("step1", "i-attempt1")
         report_1 = QuantumGraphExecutionReport.make_reports(helper.butler, qg_1)
         summary_1 = report_1.to_summary_dict(helper.butler)
+        # Check that total between successful, blocked and failed is expected
+        for task in summary_1:
+            self.assertEqual(
+                summary_1[task]["n_expected"],
+                sum(
+                    [
+                        summary_1[task]["n_succeeded"],
+                        summary_1[task]["n_quanta_blocked"],
+                        len(summary_1[task]["failed_quanta"]),
+                    ]
+                ),
+            )
         failures = summary_1["_mock_calibrate"]["failed_quanta"]
         failed_visits = set()
         for quantum_summary in failures.values():
@@ -161,6 +173,18 @@ class ProdOutputsTestCase(unittest.TestCase):
         qg_2 = helper.get_quantum_graph("step1", "i-attempt2")
         report_2 = QuantumGraphExecutionReport.make_reports(helper.butler, qg_2)
         summary_2 = report_2.to_summary_dict(helper.butler)
+        # Check that total between successful, blocked and failed is expected
+        for task in summary_2:
+            self.assertEqual(
+                summary_2[task]["n_expected"],
+                sum(
+                    [
+                        summary_2[task]["n_succeeded"],
+                        summary_2[task]["n_quanta_blocked"],
+                        len(summary_2[task]["failed_quanta"]),
+                    ]
+                ),
+            )
         self.assertEqual(summary_2["_mock_calibrate"]["failed_quanta"], {})  # is empty ??
         # Making sure it works with the human-readable version,
         hr_summary_2 = report_2.to_summary_dict(helper.butler, human_readable=True)


### PR DESCRIPTION
Depends on [lsst/pipe_base/424](https://github.com/lsst/pipe_base/pull/424).

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
