### PR TITLE
DM-53844: Make release notes

### DIFF
--- a/doc/changes/DM-37163.feature.rst
+++ b/doc/changes/DM-37163.feature.rst
@@ -1,2 +1,0 @@
-Add tests for QuantumGraphExecutionReports using "rescues" to test reporting on
-fail-and-recover attempts for step 1.

--- a/doc/changes/DM-39672.feature.md
+++ b/doc/changes/DM-39672.feature.md
@@ -1,1 +1,0 @@
-Add tests for --skip-existing-in and the "rescue" pattern.

--- a/doc/changes/DM-41606.feature.md
+++ b/doc/changes/DM-41606.feature.md
@@ -1,1 +1,0 @@
-Add tests which exercise the human-readable option for pipetask report.

--- a/doc/changes/DM-41711.feature.md
+++ b/doc/changes/DM-41711.feature.md
@@ -1,1 +1,0 @@
-Add tests for the `QuantumProvenanceGraph`.

--- a/doc/changes/DM-42302.misc.md
+++ b/doc/changes/DM-42302.misc.md
@@ -1,1 +1,0 @@
-Drop support for Pydantic 1.x.

--- a/doc/changes/DM-44368.feature.md
+++ b/doc/changes/DM-44368.feature.md
@@ -1,1 +1,0 @@
-Add tests for counts of expected quanta in `pipetask report`.

--- a/doc/lsst.ci.middleware/CHANGES.rst
+++ b/doc/lsst.ci.middleware/CHANGES.rst
@@ -1,0 +1,46 @@
+lsst-ci-middleware v30.0.0 (2026-01-16)
+=======================================
+
+New Features
+------------
+
+- Use ``aggregate-graph`` to ingest QBB outputs. (`DM-52360 <https://jira.lsstcorp.org/browse/DM-52360>`_)
+
+
+lsst-ci-middleware v28.0.0 (2024-11-20)
+=======================================
+
+New Features
+------------
+
+- Added tests for counts of expected quanta in ``pipetask report``. (`DM-44368 <https://jira.lsstcorp.org/browse/DM-44368>`_)
+- Added tests for the ``QuantumProvenanceGraph``. (`DM-41711 <https://jira.lsstcorp.org/browse/DM-41711>`_)
+
+lsst-ci-middleware v26.0.2 (2024-03-20)
+=======================================
+
+New Features
+------------
+
+- Added tests which exercise the human-readable option for ``pipetask report``. (`DM-41606 <https://jira.lsstcorp.org/browse/DM-41606>`_)
+
+lsst-ci-middleware v26.0.1 (2024-01-30)
+=======================================
+
+New Features
+------------
+
+- Added tests for ``QuantumGraphExecutionReports`` using "rescues" to test reporting on fail-and-recover attempts for step 1. (`DM-37163 <https://jira.lsstcorp.org/browse/DM-37163>`_)
+
+Other Changes and Additions
+---------------------------
+
+- Dropped support for Pydantic 1.x. (`DM-42302 <https://jira.lsstcorp.org/browse/DM-42302>`_)
+
+lsst-ci-middleware v26.0.2 (2023-09-22)
+=======================================
+
+New Features
+------------
+
+- Added tests for ``--skip-existing-in`` and the "rescue" pattern. (`DM-39672 <https://jira.lsstcorp.org/browse/DM-39672>`_)

--- a/doc/lsst.ci.middleware/index.rst
+++ b/doc/lsst.ci.middleware/index.rst
@@ -18,6 +18,17 @@ lsst.ci.middleware
 .. .. toctree::
 ..    :maxdepth: 1
 
+.. _lsst.ci.middleware-changes:
+
+Changes
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   CHANGES.rst
+
+
 .. _lsst.ci.middleware-contributing:
 
 Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.towncrier]
-    package = "lsst.ci_middleware"
+    package = "lsst.ci.middleware"
     package_dir = "python"
-    filename = "doc/lsst.ci_middleware/CHANGES.rst"
+    filename = "doc/lsst.ci.middleware/CHANGES.rst"
     directory = "doc/changes"
-    title_format = "obs_base {version} ({project_date})"
+    title_format = "lsst-ci-middleware {version} ({project_date})"
     issue_format = "`{issue} <https://jira.lsstcorp.org/browse/{issue}>`_"
 
     [[tool.towncrier.type]]


### PR DESCRIPTION
This hasn't been done consistently but uses what is there.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
